### PR TITLE
Fix: Ensure ConfluenceImportView calls task with dummy_zip_path

### DIFF
--- a/workdir/importer/views.py
+++ b/workdir/importer/views.py
@@ -20,7 +20,8 @@ class ConfluenceImportView(APIView):
         try:
             import_confluence_space.delay(
                 uploaded_file_id=placeholder_uploaded_file_id,
-                user_id=user_id_to_pass
+                user_id=user_id_to_pass,
+                dummy_zip_path_for_testing="dummy_confluence_export_for_task.zip"
             )
             message = f"Confluence space import initiated for placeholder file ID: {placeholder_uploaded_file_id}."
             print(f"ConfluenceImportView: Dispatched task for user {user_id_to_pass}, placeholder_id {placeholder_uploaded_file_id}")


### PR DESCRIPTION
The ConfluenceImportView was not passing the 'dummy_zip_path_for_testing' argument to the 'import_confluence_space' Celery task. This prevented the Proof-of-Concept (PoC) importer from finding and processing the test ZIP file as intended.

This commit updates ConfluenceImportView to correctly pass "dummy_confluence_export_for_task.zip" as the
'dummy_zip_path_for_testing' argument to the task.

Additionally, a new test suite, ConfluenceImportViewTests, has been added to importer/tests.py. This test mocks the Celery task and verifies that the view:
- Responds with HTTP 202 ACCEPTED on a POST request.
- Calls the import_confluence_space task once.
- Calls the task with the correct 'uploaded_file_id', 'user_id', and 'dummy_zip_path_for_testing' arguments.

These changes ensure the PoC Confluence importer can be triggered correctly as per its current design and README description.