### PR TITLE
Fix: Resolve Flower startup and lowlight import errors

### DIFF
--- a/conflu_frontend/src/components/content/RenderedPageContent.tsx
+++ b/conflu_frontend/src/components/content/RenderedPageContent.tsx
@@ -14,7 +14,7 @@ import HorizontalRule from '@tiptap/extension-horizontal-rule';
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 
 // For CodeBlockLowlight
-import { lowlight } from 'lowlight/lib/core'; // Use /core for smaller bundle if only registering some languages
+import { lowlight } from 'lowlight'; // Use /core for smaller bundle if only registering some languages
 import html from 'highlight.js/lib/languages/xml'; // XML for HTML
 import css from 'highlight.js/lib/languages/css';
 import javascript from 'highlight.js/lib/languages/javascript';

--- a/conflu_frontend/src/components/editor/TiptapEditor.tsx
+++ b/conflu_frontend/src/components/editor/TiptapEditor.tsx
@@ -14,7 +14,7 @@ import HorizontalRule from '@tiptap/extension-horizontal-rule';
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 
 // For CodeBlockLowlight - import lowlight and languages as in RenderedPageContent
-import { lowlight } from 'lowlight/lib/core';
+import { lowlight } from 'lowlight';
 import html from 'highlight.js/lib/languages/xml';
 import css from 'highlight.js/lib/languages/css';
 import javascript from 'highlight.js/lib/languages/javascript';

--- a/workdir/docker-compose.yml
+++ b/workdir/docker-compose.yml
@@ -62,11 +62,12 @@ services:
       - db # Tasks might interact with the database
 
   flower:
-    image: mher/flower:2.0.1 # Aligning with installed flower version
-    command: flower --broker=${REDIS_URL:-redis://redis:6379/0} --basic_auth=${FLOWER_USER:-user}:${FLOWER_PASSWORD:-pass}
+    build: .
+    command: celery -A conflu_project_root_config.celery flower --broker=${REDIS_URL:-redis://redis:6379/0} --basic_auth=${FLOWER_USER:-user}:${FLOWER_PASSWORD:-pass}
     ports:
       - "5555:5555"
     environment:
+      - DJANGO_SETTINGS_MODULE=conflu_project_root_config.settings
       # REDIS_URL for broker connection by Flower
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
       # Basic auth credentials for Flower UI

--- a/workdir/localdeploy.md
+++ b/workdir/localdeploy.md
@@ -52,7 +52,7 @@ The `workdir/docker-compose.yml` file is configured to set up the backend servic
     docker-compose build
     docker-compose up -d
     ```
-    This will build the Docker images (if not already built) and start all services defined in `docker-compose.yml` in detached mode.
+        This will build the Docker images for services like `backend`, `celeryworker`, and `flower` (if not already built or if their Dockerfile/context has changed) and start all services defined in `docker-compose.yml` in detached mode.
 
 3.  **Run Database Migrations:**
     Once the services are running, apply database migrations:
@@ -71,6 +71,7 @@ The `workdir/docker-compose.yml` file is configured to set up the backend servic
     *   **Backend API:** Typically available at `http://localhost:8000/api/v1/` (or the port mapped in `docker-compose.yml`). The Django admin interface is at `http://localhost:8000/admin/`.
     *   **PostgreSQL Database:** Port `5432` is usually exposed to the host as `5433` (check `docker-compose.yml`).
     *   **Redis:** Port `6379` is usually exposed (check `docker-compose.yml`).
+    *   **Flower (Celery Monitoring):** Accessible at `http://localhost:5555`. The Flower service is used to monitor Celery tasks and workers. It is now built using the project's main `Dockerfile` (the same one used for the `backend` and `celeryworker` services), and the `flower` package has been added to `requirements.txt`. Its command and environment are configured in `docker-compose.yml`.
 
 6.  **Running Backend Tests:**
     To run the Django backend tests:

--- a/workdir/requirements.txt
+++ b/workdir/requirements.txt
@@ -17,3 +17,4 @@ django-allauth~=0.58.2
 dj-rest-auth~=5.0.0
 beautifulsoup4>=4.12,<4.13
 lxml>=4.9,<5.2
+flower


### PR DESCRIPTION
This commit addresses two main issues:

1.  **Flower Service Startup:**
    - The Flower service in `docker-compose.yml` was previously using the `mher/flower:2.0.1` image and failing because the `flower` executable was not found.
    - The service has been changed to `build: .`, utilizing the same local Dockerfile as the backend and celeryworker.
    - The command has been updated to `celery -A conflu_project_root_config.celery flower ...` for robust startup.
    - `DJANGO_SETTINGS_MODULE` has been added to its environment variables.
    - The `flower` package has been added to `workdir/requirements.txt`.
    - `workdir/localdeploy.md` has been updated to reflect these changes.

2.  **Lowlight Frontend Imports:**
    - The frontend components `TiptapEditor.tsx` and `RenderedPageContent.tsx` were importing `lowlight` using a deep path (`lowlight/lib/core`).
    - This caused "Package subpath 'undefined' is not defined by 'exports'" errors with Vite.
    - The import paths have been changed to the correct `import { lowlight } from 'lowlight';`.

These changes should improve the local deployment experience and fix the reported runtime errors.